### PR TITLE
A weechat user had difficulty connecting to OFTC with the CertFP guide

### DIFF
--- a/NickServ/CertFP.md
+++ b/NickServ/CertFP.md
@@ -291,6 +291,8 @@ your newly generated certificate. Note that we use the SSL port 6697 to connect.
 /set irc.server.OFTC.ssl_cert %h/certs/nick.pem
 {% endhighlight %}
 
+You may need to set the weechat.network.gnutls_ca_file variable.
+
 Now connect back to the server.
 
 `/connect OFTC`


### PR DESCRIPTION
The user's solution wasn't directly applicable to the configuration advice
already in the section but the variable named looked useful enough to
write down for others to find.
