### PR TITLE
Improve documentation

### DIFF
--- a/Services.md
+++ b/Services.md
@@ -27,6 +27,14 @@ client certificates. For more information about this feature please look at
 
 `/msg NickServ help` will give you an overview of other NickServ commands.
 
+### Verify your account ###
+
+When you register an account, NickServ will give you a link to a web page
+where you can verify your account. You will need to solve a CAPTCHA in
+order to verify your account. The link will expire after one hour, but
+you can ask for a new link with `/msg NickServ REVERIFY`. If you need any
+assistance, please ask for help from OFTC staff in #oftc or on support@oftc.net.
+
 ### Register your channel ###
 
 For channel registration, the ChanServ bot is provided. To register a channel

--- a/documentation.md
+++ b/documentation.md
@@ -6,6 +6,7 @@ title: Documentation
 
  * [UserModes](/UserModes/)
  * [ChannelModes](/ChannelModes/)
+ * [Services](/Services/)
  * [NickServ](/NickServ/CertFP/)
  * [GroupServ](/GroupServ/)
  * [UserCloaks](/UserCloaks/)

--- a/staff.md
+++ b/staff.md
@@ -30,8 +30,8 @@ If you would like to join our staff or sponsor a server, please refer to our
 
 ## Inquiries ##
 
-Please address all general inquiries, requests, and comments to support:
-support@oftc.net.
+Please address all general inquiries, requests, and comments to the
+`#oftc` channel or by email to support@oftc.net.
 
 ## Network Operations Committee Chair ##
 


### PR DESCRIPTION
Document the new account verification workflow.

Link to the services documentation from the documentation index.

Document the #oftc IRC channel on the staff page.